### PR TITLE
release `8.0.1`

### DIFF
--- a/Songhay.Modules.Publications.Tests/LegacyPresentationUtility.fs
+++ b/Songhay.Modules.Publications.Tests/LegacyPresentationUtility.fs
@@ -285,6 +285,7 @@ module LegacyPresentationUtility =
                 {
                     id = id
                     title = title
+                    cssCustomPropertiesAndValues = cssVariableAndValues
                     cssVariables = cssVariableAndValues
                     parts = [
                         description

--- a/Songhay.Modules.Publications.Tests/LegacyPresentationUtility.fs
+++ b/Songhay.Modules.Publications.Tests/LegacyPresentationUtility.fs
@@ -253,29 +253,29 @@ module LegacyPresentationUtility =
                 |> tryGetPresentationIdResult
                 |> toResultFromStringElement (fun el -> el.GetString() |> Identifier.fromString |> Id)
 
-            and! title =
+            let! title =
                 presentationElementResult
                 |> tryGetPresentationTitleResult
                 |> toResultFromStringElement (fun el -> el.GetString() |> Title)
 
-            and! cssVariableAndValues =
+            let! cssVariableAndValues =
                 presentationElementResult
                 |> tryGetLayoutMetadataResult
                 |> toPresentationCssVariablesResult
 
-            and! description =
+            let! description =
                 presentationElementResult
                 |> tryGetPresentationDescriptionResult
                 |> toResultFromStringElement (fun el -> el.GetString() |> PresentationDescription)
 
-            and! creditList = creditsResult
+            let! creditList = creditsResult
 
-            and! copyrights =
+            let! copyrights =
                 presentationElementResult
                 |> tryGetCopyrightResult
                 |> toPresentationCopyrights
 
-            and! playlist =
+            let! playlist =
                 presentationElementResult
                 |> tryGetPlaylistRootResult
                 |> toPresentationPlaylistResult

--- a/Songhay.Modules.Publications.Tests/Songhay.Modules.Publications.Tests.fsproj
+++ b/Songhay.Modules.Publications.Tests/Songhay.Modules.Publications.Tests.fsproj
@@ -34,15 +34,14 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FSharp.SystemTextJson" Version="1.3.13" />
         <PackageReference Include="FsUnit.xUnit" Version="6.0.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-        <PackageReference Include="xunit" Version="2.9.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.2">
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Songhay.Modules.Publications/DisplayItemModelUtility.fs
+++ b/Songhay.Modules.Publications/DisplayItemModelUtility.fs
@@ -83,9 +83,9 @@ module DisplayItemModelUtility =
         result {
 
             let! id = (useCamelCase, element) ||> Id.fromInput itemType
-            and! name = (useCamelCase, element) ||> Name.fromInput itemType
-            and! displayText =  (useCamelCase, element) ||> displayTextGetter itemType
-            and! resourceIndicator =
+            let! name = (useCamelCase, element) ||> Name.fromInput itemType
+            let! displayText =  (useCamelCase, element) ||> displayTextGetter itemType
+            let! resourceIndicator =
                 match resourceIndicatorGetter with
                 | Some getter -> ((useCamelCase, element) ||> getter itemType)
                 | _ -> Ok None

--- a/Songhay.Modules.Publications/Models/Presentation.fs
+++ b/Songhay.Modules.Publications/Models/Presentation.fs
@@ -21,6 +21,7 @@ type Presentation =
         ///<summary>The Presentation <see cref="PresentationPart"/> collection.</summary>
         parts: PresentationPart list
     }
+
     static member internal getJsonOptions() =
         let options = JsonSerializerOptions()
         options.Converters.Add(JsonFSharpConverter())

--- a/Songhay.Modules.Publications/Models/Presentation.fs
+++ b/Songhay.Modules.Publications/Models/Presentation.fs
@@ -17,6 +17,9 @@ type Presentation =
         ///<summary>The Presentation title.</summary>
         title: Title
         ///<summary>The Presentation <see cref="CssCustomPropertyAndValue"/> collection.</summary>
+        cssCustomPropertiesAndValues: CssCustomPropertyAndValue list
+        ///<summary>The Presentation <see cref="CssCustomPropertyAndValue"/> collection.</summary>
+        [<Obsolete("Use `cssCustomPropertiesAndValues` instead.")>]
         cssVariables: CssCustomPropertyAndValue list
         ///<summary>The Presentation <see cref="PresentationPart"/> collection.</summary>
         parts: PresentationPart list

--- a/Songhay.Modules.Publications/Models/PresentationPrimitives.fs
+++ b/Songhay.Modules.Publications/Models/PresentationPrimitives.fs
@@ -30,6 +30,45 @@ type Description =
     override this.ToString() = match this with Description dt -> dt.Value
 
 /// <summary>
+/// Defines the Publication document concepts
+/// </summary>
+type PresentationDocument =
+    ///<summary>Identifies a <see cref="string" /> as CSV.</summary>
+    | Csv of string
+    ///<summary>Identifies a <see cref="string" /> as HTML.</summary>
+    | Html of string
+    ///<summary>Identifies a <see cref="string" /> as JSON.</summary>
+    | Json of string
+    ///<summary>Identifies a <see cref="string" /> as plain text demarcated by line breaks.</summary>
+    | Lines of string list
+    ///<summary>Identifies a <see cref="string" /> as Markdown.</summary>
+    | Markdown of string
+    ///<summary>Identifies a document with a conventional identifier (<see cref="Uri"/>).</summary>
+    | Permalink of Uri
+    ///<summary>Identifies a <see cref="string" /> as SVG.</summary>
+    | Svg of string
+    ///<summary>Identifies a <see cref="string" /> as TTML (Timed Text Markup Language).</summary>
+    | Ttml of string
+    ///<summary>Identifies a <see cref="string" /> as XHTML.</summary>
+    | Xhtml of string
+    ///<summary>Identifies a <see cref="string" /> as YAML.</summary>
+    | Yaml of string
+
+    ///<summary>Returns the <see cref="string" /> representation of this instance.</summary>
+    override this.ToString() =
+        match this with
+        | Csv csv -> csv
+        | Html html -> html
+        | Json json -> json
+        | Lines l -> l |> List.reduce (fun a i -> $"{a}{Environment.NewLine}{i}")
+        | Markdown md -> md
+        | Permalink uri -> uri.OriginalString
+        | Svg svg -> svg
+        | Ttml ttml -> ttml
+        | Xhtml xhtml -> xhtml
+        | Yaml yaml -> yaml
+
+/// <summary>
 /// Defines Publication credits
 /// </summary>
 type RoleCredit =
@@ -68,6 +107,8 @@ type PresentationPart =
     | Pages of string list
     ///<summary><see cref="Presentation"/> playlist.</summary>
     | Playlist of (DisplayText * Uri) list
+    ///<summary><see cref="Presentation"/> documents.</summary>
+    | PresentationDocuments of PresentationDocument
     ///<summary><see cref="Presentation"/> stream.</summary>
     | Stream of StreamSegment list
 
@@ -79,7 +120,8 @@ type PresentationPart =
     ///<summary>Returns the <see cref="string" /> collection representation of this instance.</summary>
     member this.StringValues =
         match this with
-        | CopyRights l -> l |> List.map (fun i -> i.ToString())
+        | CopyRights l -> l |> List.map _.ToString()
         | Pages l -> l
         | Playlist l -> l |> List.map (fun (dt, _) -> dt.Value)
         | _ -> [this.ToString()]
+    

--- a/Songhay.Modules.Publications/Songhay.Modules.Publications.fsproj
+++ b/Songhay.Modules.Publications/Songhay.Modules.Publications.fsproj
@@ -14,8 +14,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="FsToolkit.ErrorHandling" Version="4.18.0" />
-      <PackageReference Include="Songhay.Modules" Version="8.0.0" />
+      <PackageReference Include="FSharp.SystemTextJson" Version="1.4.36" />
+      <PackageReference Include="FsToolkit.ErrorHandling" Version="5.0.0" />
+      <PackageReference Include="Songhay.Modules" Version="8.0.1" />
       <PackageReference Remove="FSharp.Core" />
     </ItemGroup>
 

--- a/Songhay.Modules.Publications/SyndicationFeedUtility.fs
+++ b/Songhay.Modules.Publications/SyndicationFeedUtility.fs
@@ -93,7 +93,7 @@ module SyndicationFeedUtility =
     let toSyndicationFeedItem (titleResult: Result<string,JsonException>, linkResult: Result<string,JsonException>) =
         result {
             let! title = titleResult
-            and! link = linkResult
+            let! link = linkResult
 
             return
                 {


### PR DESCRIPTION
>[!important]
>Because `error FS0222` reported last year continues to be relevant, this Studio will hold back `FsUnit.xUnit` to versions less than 7.0.

- [x] upgrade packages 📦🔝
- [x] run tests ☔
- [x] address #10 🔨
- [x] address #11 🔨
- [ ] address #12 🔨

### `FsToolkit.ErrorHandling` Error `FS3343`

Upgrading `FsToolkit.ErrorHandling` to `5.x` broke the build:

```console
Error FS3343 : The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a 'Bind4' method or appropriate 'MergeSources' and 'Bind' methods
```

This must be because of changes to `FsToolkit.ErrorHandling.ResultCE.result` \[🔗 [GitHub](https://github.com/demystifyfp/FsToolkit.ErrorHandling/blob/master/src/FsToolkit.ErrorHandling/ResultCE.fs) \] such that this is no longer supported:

```fsharp
result {

    let! id = (useCamelCase, element) ||> Id.fromInput itemType
    and! name = (useCamelCase, element) ||> Name.fromInput itemType
    and! displayText =  (useCamelCase, element) ||> displayTextGetter itemType
    and! resourceIndicator =
        match resourceIndicatorGetter with
        | Some getter -> ((useCamelCase, element) ||> getter itemType)
        | _ -> Ok None

    return
        {
            id = id
            itemName = name.toItemName
            displayText = displayText
            resourceIndicator = resourceIndicator
        }
}
```

…my quick fix is to fall back to non-parallelism, causing a performance hit:

```fsharp
result {

    let! id = (useCamelCase, element) ||> Id.fromInput itemType
    let! name = (useCamelCase, element) ||> Name.fromInput itemType
    let! displayText =  (useCamelCase, element) ||> displayTextGetter itemType
    let! resourceIndicator =
        match resourceIndicatorGetter with
        | Some getter -> ((useCamelCase, element) ||> getter itemType)
        | _ -> Ok None

    return
        {
            id = id
            itemName = name.toItemName
            displayText = displayText
            resourceIndicator = resourceIndicator
        }
}
```

There appears to be one issue in the `FsToolkit.ErrorHandling` repo that recognizes my problem here: “[Question: parallel async CE #333](https://github.com/demystifyfp/FsToolkit.ErrorHandling/issues/333)”  The following comment sounds ominous:

>…`and!` for the official `async` CE was rejected.
>
>—<https://github.com/demystifyfp/FsToolkit.ErrorHandling/issues/333#issuecomment-2969639301>
>

…where the phrase “was rejected” suggests (to me) that the `FsToolkit.ErrorHandling` folks were not the cause of this breaking change.
